### PR TITLE
[codex] Stabiliser le modèle public des Tags

### DIFF
--- a/apps/romainlanz.com/app/core/slug.ts
+++ b/apps/romainlanz.com/app/core/slug.ts
@@ -1,0 +1,9 @@
+import string from '@adonisjs/core/helpers/string';
+
+export function generateSlug(value: string) {
+	return string.slug(value, {
+		lower: true,
+		strict: true,
+		trim: true,
+	});
+}

--- a/apps/romainlanz.com/app/taxonomies/domain/tag.ts
+++ b/apps/romainlanz.com/app/taxonomies/domain/tag.ts
@@ -1,0 +1,16 @@
+import { Entity } from '#core/domain/entity';
+import type { TagIdentifier } from './tag_identifier.js';
+import type { TagColor } from '@rlanz/design-system/tag-color';
+
+interface Properties {
+	id: TagIdentifier;
+	name: string;
+	slug: string;
+	color: TagColor;
+}
+
+export class Tag extends Entity<Properties> {
+	static create(properties: Properties) {
+		return new this(properties);
+	}
+}

--- a/apps/romainlanz.com/app/taxonomies/domain/tag_color.ts
+++ b/apps/romainlanz.com/app/taxonomies/domain/tag_color.ts
@@ -1,0 +1,9 @@
+import { isTagColor, type TagColor } from '@rlanz/design-system/tag-color';
+
+export function parseTagColor(color: string): TagColor {
+	if (!isTagColor(color)) {
+		throw new Error(`Unsupported tag color "${color}"`);
+	}
+
+	return color;
+}

--- a/apps/romainlanz.com/app/taxonomies/domain/tag_identifier.ts
+++ b/apps/romainlanz.com/app/taxonomies/domain/tag_identifier.ts
@@ -1,0 +1,3 @@
+import { Identifier } from '#core/domain/identifier';
+
+export class TagIdentifier extends Identifier<'TagIdentifier'> {}

--- a/apps/romainlanz.com/app/taxonomies/queries/find_tag_by_slug_query.ts
+++ b/apps/romainlanz.com/app/taxonomies/queries/find_tag_by_slug_query.ts
@@ -1,0 +1,26 @@
+import { RecordNotFoundException } from '#core/exceptions/record_not_found_exception';
+import { db } from '#core/services/db';
+import { Tag } from '#taxonomies/domain/tag';
+import { parseTagColor } from '#taxonomies/domain/tag_color';
+import { TagIdentifier } from '#taxonomies/domain/tag_identifier';
+
+export class FindTagBySlugQuery {
+	async execute(slug: string) {
+		const tagRecord = await db
+			.selectFrom('tags')
+			.select(['id', 'name', 'slug', 'color'])
+			.where('slug', '=', slug)
+			.executeTakeFirst();
+
+		if (!tagRecord) {
+			throw new RecordNotFoundException();
+		}
+
+		return Tag.create({
+			id: TagIdentifier.fromString(tagRecord.id),
+			name: tagRecord.name,
+			slug: tagRecord.slug,
+			color: parseTagColor(tagRecord.color),
+		});
+	}
+}

--- a/apps/romainlanz.com/app/taxonomies/queries/list_tags_query.ts
+++ b/apps/romainlanz.com/app/taxonomies/queries/list_tags_query.ts
@@ -1,0 +1,19 @@
+import { db } from '#core/services/db';
+import { Tag } from '#taxonomies/domain/tag';
+import { parseTagColor } from '#taxonomies/domain/tag_color';
+import { TagIdentifier } from '#taxonomies/domain/tag_identifier';
+
+export class ListTagsQuery {
+	async execute() {
+		const tagRecords = await db.selectFrom('tags').select(['id', 'name', 'slug', 'color']).orderBy('name').execute();
+
+		return tagRecords.map((tagRecord) => {
+			return Tag.create({
+				id: TagIdentifier.fromString(tagRecord.id),
+				name: tagRecord.name,
+				slug: tagRecord.slug,
+				color: parseTagColor(tagRecord.color),
+			});
+		});
+	}
+}

--- a/apps/romainlanz.com/app/taxonomies/repositories/tag_repository.ts
+++ b/apps/romainlanz.com/app/taxonomies/repositories/tag_repository.ts
@@ -1,0 +1,95 @@
+import { RecordNotFoundException } from '#core/exceptions/record_not_found_exception';
+import { db } from '#core/services/db';
+import { generateSlug } from '#core/slug';
+import { Tag } from '#taxonomies/domain/tag';
+import { parseTagColor } from '#taxonomies/domain/tag_color';
+import { TagIdentifier } from '#taxonomies/domain/tag_identifier';
+
+interface CreateTagDTO {
+	name: string;
+	color: string;
+}
+
+interface UpdateTagDTO {
+	id: string;
+	name: string;
+	color: string;
+}
+
+export class TagRepository {
+	async create(payload: CreateTagDTO) {
+		const color = parseTagColor(payload.color);
+		const baseSlug = generateSlug(payload.name) || 'tag';
+		let suffix = 1;
+
+		while (true) {
+			const slug = suffix === 1 ? baseSlug : `${baseSlug}-${suffix}`;
+			const id = TagIdentifier.generate();
+
+			try {
+				await db
+					.insertInto('tags')
+					.values({
+						id: id.toString(),
+						name: payload.name,
+						slug,
+						color,
+					})
+					.execute();
+
+				return Tag.create({
+					id,
+					name: payload.name,
+					slug,
+					color,
+				});
+			} catch (error) {
+				if (!isTagSlugUniqueConstraintViolation(error)) {
+					throw error;
+				}
+
+				suffix += 1;
+			}
+		}
+	}
+
+	async update(payload: UpdateTagDTO) {
+		const color = parseTagColor(payload.color);
+		const existingTag = await db
+			.selectFrom('tags')
+			.select(['id', 'slug'])
+			.where('id', '=', payload.id)
+			.executeTakeFirst();
+
+		if (!existingTag) {
+			throw new RecordNotFoundException();
+		}
+
+		await db
+			.updateTable('tags')
+			.set({
+				name: payload.name,
+				color,
+			})
+			.where('id', '=', payload.id)
+			.execute();
+
+		return Tag.create({
+			id: TagIdentifier.fromString(existingTag.id),
+			name: payload.name,
+			slug: existingTag.slug,
+			color,
+		});
+	}
+}
+
+function isTagSlugUniqueConstraintViolation(error: unknown) {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		error.code === '23505' &&
+		'constraint' in error &&
+		error.constraint === 'tags_slug_unique'
+	);
+}

--- a/apps/romainlanz.com/database/migrations/1749688200000_add_slug_to_tags_table.ts
+++ b/apps/romainlanz.com/database/migrations/1749688200000_add_slug_to_tags_table.ts
@@ -1,0 +1,14 @@
+import type { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema
+		.alterTable('tags')
+		.addColumn('slug', 'text', (col) => col.notNull())
+		.execute();
+	await db.schema.alterTable('tags').addUniqueConstraint('tags_slug_unique', ['slug']).execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('tags').dropConstraint('tags_slug_unique').execute();
+	await db.schema.alterTable('tags').dropColumn('slug').execute();
+}

--- a/apps/romainlanz.com/tests/database_test_utils.ts
+++ b/apps/romainlanz.com/tests/database_test_utils.ts
@@ -1,0 +1,42 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Migrator, sql } from 'kysely';
+import { FileMigrationProvider } from '#core/file_migration_provider';
+import { db } from '#core/services/db';
+
+const migrationFolder = fileURLToPath(new URL('../database/migrations', import.meta.url));
+
+export async function migrateDatabase() {
+	const migrator = new Migrator({
+		db,
+		provider: new FileMigrationProvider({
+			fs,
+			path,
+			migrationFolder,
+		}),
+	});
+	const { error } = await migrator.migrateToLatest();
+
+	if (error) {
+		throw error;
+	}
+}
+
+export async function truncateDatabase() {
+	const { rows } = await sql<{ tablename: string }>`
+		SELECT tablename
+		FROM pg_tables
+		WHERE schemaname = 'public'
+			AND tablename NOT IN ('kysely_migration', 'kysely_migration_lock')
+	`.execute(db);
+
+	if (rows.length === 0) {
+		return;
+	}
+
+	await sql`
+		TRUNCATE TABLE ${sql.join(rows.map((row) => sql.id('public', row.tablename)))}
+		RESTART IDENTITY CASCADE
+	`.execute(db);
+}

--- a/apps/romainlanz.com/tests/factories/index.ts
+++ b/apps/romainlanz.com/tests/factories/index.ts
@@ -1,5 +1,7 @@
+import { tagColors } from '@rlanz/design-system/tag-color';
 import { ArticleStatus } from '#articles/enums/article_status';
 import { UserRole } from '#auth/enums/user_role';
+import { generateSlug } from '#core/slug';
 import { KyselyFactory, defineFactory, resolveRelation } from './factory.js';
 import type { FactoryRelationValue } from './factory.js';
 
@@ -28,11 +30,16 @@ export const CategoryFactory = defineFactory('categories', ({ faker }) => ({
 	illustration_name: 'code',
 }));
 
-export const TagFactory = defineFactory('tags', ({ faker }) => ({
-	id: faker.string.uuid(),
-	name: faker.word.noun(),
-	color: faker.color.rgb(),
-}));
+export const TagFactory = defineFactory('tags', ({ faker, sequence }) => {
+	const name = faker.word.words({ count: { min: 1, max: 2 } });
+
+	return {
+		id: faker.string.uuid(),
+		name,
+		slug: generateSlug(`${name} ${sequence}`),
+		color: faker.helpers.arrayElement(tagColors),
+	};
+});
 
 export const ArticleFactory = defineFactory('articles', async ({ faker, sequence }) => {
 	const title = faker.lorem.sentence({ min: 3, max: 6 });

--- a/apps/romainlanz.com/tests/fixtures/base_fixture.ts
+++ b/apps/romainlanz.com/tests/fixtures/base_fixture.ts
@@ -1,0 +1,26 @@
+import { getActiveTest } from '@japa/runner';
+import type { Test } from '@japa/runner/core';
+
+export class BaseFixture {
+	#test: Test<any> | undefined;
+
+	protected getActiveTest() {
+		if (this.#test) {
+			return this.#test;
+		}
+
+		const activeTest = getActiveTest();
+
+		if (!activeTest) {
+			throw new Error('Cannot access the current test context outside of a running test');
+		}
+
+		this.#test = activeTest;
+
+		return activeTest;
+	}
+
+	get assert() {
+		return this.getActiveTest().context.assert;
+	}
+}

--- a/apps/romainlanz.com/tests/fixtures/database_fixture.ts
+++ b/apps/romainlanz.com/tests/fixtures/database_fixture.ts
@@ -1,0 +1,9 @@
+import { migrateDatabase, truncateDatabase } from '#tests/database_test_utils';
+import { BaseFixture } from '#tests/fixtures/base_fixture';
+
+export class DatabaseFixture extends BaseFixture {
+	async resetDatabase() {
+		await migrateDatabase();
+		await truncateDatabase();
+	}
+}

--- a/apps/romainlanz.com/tests/fixtures/tag_fixture.ts
+++ b/apps/romainlanz.com/tests/fixtures/tag_fixture.ts
@@ -1,0 +1,53 @@
+import { FindTagBySlugQuery } from '#taxonomies/queries/find_tag_by_slug_query';
+import { ListTagsQuery } from '#taxonomies/queries/list_tags_query';
+import { TagRepository } from '#taxonomies/repositories/tag_repository';
+import { DatabaseFixture } from '#tests/fixtures/database_fixture';
+import type { Tag } from '#taxonomies/domain/tag';
+import type { TagColor } from '@rlanz/design-system/tag-color';
+
+interface TagAttributes {
+	name: string;
+	color: string;
+}
+
+export class TagFixture extends DatabaseFixture {
+	readonly #repository = new TagRepository();
+	readonly #findTagBySlug = new FindTagBySlugQuery();
+	readonly #listTags = new ListTagsQuery();
+
+	async givenATagExists(attributes: Partial<TagAttributes> = {}) {
+		return this.whenICreateATag({
+			name: 'Adonis JS',
+			color: 'cyan',
+			...attributes,
+		});
+	}
+
+	whenICreateATag(attributes: TagAttributes) {
+		return this.#repository.create(attributes);
+	}
+
+	whenIRenameTag(tag: Tag, attributes: TagAttributes) {
+		return this.#repository.update({
+			id: tag.getIdentifier().toString(),
+			...attributes,
+		});
+	}
+
+	async whenIListTags() {
+		return this.#listTags.execute();
+	}
+
+	async thenTagShouldExposePublicData(slug: string, expected: { name: string; slug: string; color: TagColor }) {
+		const tag = await this.#findTagBySlug.execute(slug);
+
+		this.assert.deepEqual(
+			{
+				name: tag.props.name,
+				slug: tag.props.slug,
+				color: tag.props.color,
+			},
+			expected,
+		);
+	}
+}

--- a/apps/romainlanz.com/tests/unit/taxonomies/tag_public_model.spec.ts
+++ b/apps/romainlanz.com/tests/unit/taxonomies/tag_public_model.spec.ts
@@ -1,0 +1,96 @@
+import { test } from '@japa/runner';
+import { TagFixture } from '#tests/fixtures/tag_fixture';
+
+test.group('Tag public model', (group) => {
+	let fixture: TagFixture;
+
+	group.each.setup(async () => {
+		fixture = new TagFixture();
+		await fixture.resetDatabase();
+	});
+
+	test('creates a tag with a slug generated from its name', async () => {
+		const tag = await fixture.whenICreateATag({
+			name: 'Vue JS',
+			color: 'cyan',
+		});
+
+		await fixture.thenTagShouldExposePublicData(tag.props.slug, {
+			name: 'Vue JS',
+			slug: 'vue-js',
+			color: 'cyan',
+		});
+	});
+
+	test('keeps generated slugs unique when names collide', async () => {
+		const firstTag = await fixture.whenICreateATag({
+			name: 'Vue JS',
+			color: 'cyan',
+		});
+		const secondTag = await fixture.whenICreateATag({
+			name: 'Vue-JS',
+			color: 'yellow',
+		});
+
+		await fixture.thenTagShouldExposePublicData(firstTag.props.slug, {
+			name: 'Vue JS',
+			slug: 'vue-js',
+			color: 'cyan',
+		});
+		await fixture.thenTagShouldExposePublicData(secondTag.props.slug, {
+			name: 'Vue-JS',
+			slug: 'vue-js-2',
+			color: 'yellow',
+		});
+	});
+
+	test('keeps the public slug stable after a rename', async () => {
+		const tag = await fixture.givenATagExists({
+			name: 'Adonis JS',
+			color: 'red',
+		});
+		const renamedTag = await fixture.whenIRenameTag(tag, {
+			name: 'Adonis JS Framework',
+			color: 'violet',
+		});
+
+		await fixture.thenTagShouldExposePublicData(renamedTag.props.slug, {
+			name: 'Adonis JS Framework',
+			slug: 'adonis-js',
+			color: 'violet',
+		});
+	});
+
+	test('lists tags with their public fields', async () => {
+		await fixture.whenICreateATag({
+			name: 'Node JS',
+			color: 'lime',
+		});
+
+		const tags = await fixture.whenIListTags();
+
+		fixture.assert.deepEqual(
+			tags.map((tag) => ({
+				name: tag.props.name,
+				slug: tag.props.slug,
+				color: tag.props.color,
+			})),
+			[
+				{
+					name: 'Node JS',
+					slug: 'node-js',
+					color: 'lime',
+				},
+			],
+		);
+	});
+
+	test('rejects colors outside the design system variants', async () => {
+		await fixture.assert.rejects(async () => {
+			await fixture.whenICreateATag({
+				name: 'TypeScript',
+				color: 'orange',
+			});
+		}, /Unsupported tag color "orange"/);
+	});
+});

--- a/apps/romainlanz.com/types/db.ts
+++ b/apps/romainlanz.com/types/db.ts
@@ -82,6 +82,7 @@ export interface Tags {
   color: string;
   id: string;
   name: string;
+  slug: string;
 }
 
 export interface Users {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -24,6 +24,7 @@
 		"./reference-link": "./src/atoms/reference_link/reference_link.vue",
 		"./table": "./src/atoms/table/table.vue",
 		"./tag": "./src/atoms/tag/tag.vue",
+		"./tag-color": "./src/atoms/tag/tag_color.ts",
 		"./toaster": "./src/atoms/toast/index.ts",
 		"./alert-note": "./src/molecules/alert_note/alert_note.vue",
 		"./article-card": "./src/molecules/article_card/article_card.vue",

--- a/packages/design-system/src/atoms/tag/tag.vue
+++ b/packages/design-system/src/atoms/tag/tag.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
 	import { tv, type VariantProps } from 'tailwind-variants';
 	import { computed } from 'vue';
+	import type { TagColor } from './tag_color.js';
 
 	const props = defineProps<{
-		color?: TagProps['color'];
+		color?: TagColor;
 		href?: string;
 	}>();
 
@@ -30,7 +31,9 @@
 		},
 	});
 
-	export type TagProps = VariantProps<typeof tag>;
+	export type TagProps = Omit<VariantProps<typeof tag>, 'color'> & {
+		color?: TagColor;
+	};
 
 	const spanOrLink = computed(() => {
 		return props.href ? 'a' : 'span';

--- a/packages/design-system/src/atoms/tag/tag_color.ts
+++ b/packages/design-system/src/atoms/tag/tag_color.ts
@@ -1,0 +1,7 @@
+export const tagColors = ['cyan', 'violet', 'red', 'yellow', 'lime'] as const;
+
+export type TagColor = (typeof tagColors)[number];
+
+export function isTagColor(value: string): value is TagColor {
+	return tagColors.includes(value as TagColor);
+}


### PR DESCRIPTION
## Résumé

Cette PR implémente la tranche #46 du PRD #45 pour stabiliser le modèle public des Tags.

- Ajoute un modèle public Tag avec identifiant dédié, slug stocké, requêtes publiques et repository.
- Génère le slug à la création via le helper Adonis, garantit son unicité via contrainte SQL et retry applicatif, puis le conserve stable lors des renommages.
- Expose un contrat de couleurs aligné sur les variants du design system et l’utilise dans les factories/tests.
- Ajoute des fixtures de test lisibles pour valider le comportement public sans coupler les tests aux détails internes.

Closes #46

## Validation

- yarn workspace @rlanz/site typecheck
- yarn format:check
- yarn lint (passe avec warnings préexistants)
- yarn typecheck
- yarn workspace @rlanz/site test unit --files tests/unit/taxonomies/tag_public_model.spec.ts

## Notes

Cette PR reste volontairement limitée à la base du modèle public Tags. Elle ne démarre pas les filtres publics, l’admin complet Tags, ni l’association Tags/Articles dans les formulaires, qui restent pour les issues suivantes.