### PR TITLE
[codex] Filtrer les articles publics par tag

### DIFF
--- a/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
+++ b/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
@@ -3,6 +3,7 @@ import { CountPublishedArticlesQuery } from '#articles/queries/count_published_a
 import { ListPublishedArticlesQuery } from '#articles/queries/list_published_articles_query';
 import { ArticleListViewModel } from '#articles/view_models/article_list_view_model';
 import { FindCategoryBySlugQuery } from '#taxonomies/queries/find_category_by_slug_query';
+import { FindTagBySlugQuery } from '#taxonomies/queries/find_tag_by_slug_query';
 import { ListCategoriesWithPublishedArticlesQuery } from '#taxonomies/queries/list_categories_with_published_articles_query';
 import type { HttpContext } from '@adonisjs/core/http';
 
@@ -12,27 +13,41 @@ export default class ListArticlesController {
 		private listPublishedArticles: ListPublishedArticlesQuery,
 		private countPublishedArticles: CountPublishedArticlesQuery,
 		private findCategoryBySlug: FindCategoryBySlugQuery,
+		private findTagBySlug: FindTagBySlugQuery,
 		private listCategoriesWithPublishedArticles: ListCategoriesWithPublishedArticlesQuery,
 	) {}
 
 	async render({ request, inertia }: HttpContext) {
 		const page = Number(request.input('page', 1));
 		const categorySlug = request.input('category', null);
+		const tagSlug = request.input('tag', null);
 
 		if (categorySlug) {
 			await this.findCategoryBySlug.execute(categorySlug);
 		}
+		if (tagSlug) {
+			await this.findTagBySlug.execute(tagSlug);
+		}
 
-		const [articles, categories, allArticlesCount] = await Promise.all([
-			this.listPublishedArticles.execute({ page, perPage: 4, categorySlug }),
+		const paginationArticlesCountPromise = this.countPublishedArticles.execute({ categorySlug, tagSlug });
+		const categoryListingAllArticlesCountPromise =
+			categorySlug === null
+				? paginationArticlesCountPromise
+				: this.countPublishedArticles.execute({ categorySlug: null, tagSlug });
+
+		const [articles, categories, categoryListingAllArticlesCount, paginationArticlesCount] = await Promise.all([
+			this.listPublishedArticles.execute({ page, perPage: 4, categorySlug, tagSlug }),
 			this.listCategoriesWithPublishedArticles.execute(),
-			this.countPublishedArticles.execute(),
+			categoryListingAllArticlesCountPromise,
+			paginationArticlesCountPromise,
 		]);
 
 		return inertia.render('articles/list', {
 			activeCategory: categorySlug,
+			activeTag: tagSlug,
 			activePage: page,
-			allArticlesCount,
+			categoryListingAllArticlesCount,
+			paginationArticlesCount,
 			vm: ArticleListViewModel.fromDomain(articles, categories).serialize(),
 		});
 	}

--- a/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
+++ b/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
@@ -31,9 +31,9 @@ export default class ListArticlesController {
 
 		const paginationArticlesCountPromise = this.countPublishedArticles.execute({ categorySlug, tagSlug });
 		const categoryListingAllArticlesCountPromise =
-			categorySlug === null
+			categorySlug === null && tagSlug === null
 				? paginationArticlesCountPromise
-				: this.countPublishedArticles.execute({ categorySlug: null, tagSlug });
+				: this.countPublishedArticles.execute({ categorySlug: null, tagSlug: null });
 
 		const [articles, categories, categoryListingAllArticlesCount, paginationArticlesCount] = await Promise.all([
 			this.listPublishedArticles.execute({ page, perPage: 4, categorySlug, tagSlug }),

--- a/apps/romainlanz.com/app/articles/queries/count_published_articles_query.ts
+++ b/apps/romainlanz.com/app/articles/queries/count_published_articles_query.ts
@@ -1,12 +1,19 @@
-import { db } from '#core/services/db';
+import { inject } from '@adonisjs/core';
+import { PublishedArticlesQueryBuilder } from '#articles/queries/published_articles_query_builder';
 
+interface CountPublishedArticlesQueryInput {
+	categorySlug: string | null;
+	tagSlug: string | null;
+}
+
+@inject()
 export class CountPublishedArticlesQuery {
-	async execute() {
-		const countQueryResult = await db
-			.selectFrom('articles')
+	constructor(private publishedArticlesQueryBuilder: PublishedArticlesQueryBuilder) {}
+
+	async execute(input: CountPublishedArticlesQueryInput) {
+		const countQueryResult = await this.publishedArticlesQueryBuilder
+			.build(input)
 			.select((builder) => builder.fn.count('articles.id').as('count'))
-			.where('published_at', 'is not', null)
-			.where('published_at', '<=', new Date())
 			.execute();
 
 		return Number(countQueryResult[0].count);

--- a/apps/romainlanz.com/app/articles/queries/list_published_articles_query.ts
+++ b/apps/romainlanz.com/app/articles/queries/list_published_articles_query.ts
@@ -1,19 +1,23 @@
+import { inject } from '@adonisjs/core';
 import { DateTime } from 'luxon';
 import { Article } from '#articles/domain/article';
 import { ArticleIdentifier } from '#articles/domain/article_identifier';
-import { db } from '#core/services/db';
+import { PublishedArticlesQueryBuilder } from '#articles/queries/published_articles_query_builder';
 
 interface ListPublishedArticlesQueryInput {
 	page: number;
 	perPage: number;
 	categorySlug: string | null;
+	tagSlug: string | null;
 }
 
+@inject()
 export class ListPublishedArticlesQuery {
+	constructor(private publishedArticlesQueryBuilder: PublishedArticlesQueryBuilder) {}
+
 	async execute(input: ListPublishedArticlesQueryInput) {
-		const articleRecords = await db
-			.selectFrom('articles')
-			.leftJoin('categories', 'articles.category_id', 'categories.id')
+		const articleRecords = await this.publishedArticlesQueryBuilder
+			.build(input)
 			.select([
 				'articles.id',
 				'articles.title',
@@ -23,11 +27,6 @@ export class ListPublishedArticlesQuery {
 				'articles.reading_time',
 			])
 			.orderBy('articles.published_at', 'desc')
-			.where('articles.published_at', 'is not', null)
-			.where('articles.published_at', '<=', new Date())
-			.$if(input.categorySlug !== null, (builder) => {
-				return builder.where('categories.slug', '=', input.categorySlug!);
-			})
 			.offset((input.page - 1) * input.perPage)
 			.limit(input.perPage)
 			.execute();

--- a/apps/romainlanz.com/app/articles/queries/published_articles_query_builder.ts
+++ b/apps/romainlanz.com/app/articles/queries/published_articles_query_builder.ts
@@ -1,0 +1,25 @@
+import { db } from '#core/services/db';
+
+export interface PublishedArticlesFilters {
+	categorySlug: string | null;
+	tagSlug: string | null;
+}
+
+export class PublishedArticlesQueryBuilder {
+	build(filters: PublishedArticlesFilters) {
+		return db
+			.selectFrom('articles')
+			.leftJoin('categories', 'articles.category_id', 'categories.id')
+			.where('articles.published_at', 'is not', null)
+			.where('articles.published_at', '<=', new Date())
+			.$if(filters.categorySlug !== null, (builder) => {
+				return builder.where('categories.slug', '=', filters.categorySlug!);
+			})
+			.$if(filters.tagSlug !== null, (builder) => {
+				return builder
+					.innerJoin('tag_articles', 'articles.id', 'tag_articles.article_id')
+					.innerJoin('tags', 'tag_articles.tag_id', 'tags.id')
+					.where('tags.slug', '=', filters.tagSlug!);
+			});
+	}
+}

--- a/apps/romainlanz.com/inertia/pages/articles/list.vue
+++ b/apps/romainlanz.com/inertia/pages/articles/list.vue
@@ -8,30 +8,37 @@
 
 	const {
 		activeCategory,
+		activeTag,
 		activePage = 1,
-		allArticlesCount,
+		categoryListingAllArticlesCount,
+		paginationArticlesCount,
 		vm,
 	} = defineProps<{
 		activeCategory: string | null;
+		activeTag: string | null;
 		activePage: number;
-		allArticlesCount: number;
+		categoryListingAllArticlesCount: number;
+		paginationArticlesCount: number;
 		vm: ArticleListViewModelSerialized;
 	}>();
 
-	const paginationCount =
-		vm.categories.find((category) => category.slug === activeCategory)?.articleCount ?? allArticlesCount;
+	const paginationCount = paginationArticlesCount;
 
 	function onPageChange(page: number) {
 		const url = client.urlFor('articles.index', undefined, {
-			qs: { page, category: activeCategory },
+			qs: { page, category: activeCategory, tag: activeTag },
 		});
 		router.visit(url, {
 			preserveScroll: true,
 		});
 	}
 
+	function computeAllCategoriesHref() {
+		return client.urlFor('articles.index', undefined, { qs: { tag: activeTag } });
+	}
+
 	function computeCategoryHref(category: { slug: string }) {
-		return client.urlFor('articles.index', undefined, { qs: { category: category.slug } });
+		return client.urlFor('articles.index', undefined, { qs: { category: category.slug, tag: activeTag } });
 	}
 
 	function computeArticleHref(slug: string) {
@@ -52,8 +59,8 @@
 				<CategoryListing
 					:active-category="activeCategory"
 					:categories="vm.categories"
-					:all-href="client.urlFor('articles.index')"
-					:all-articles-count
+					:all-href="computeAllCategoriesHref()"
+					:all-articles-count="categoryListingAllArticlesCount"
 					:category-href="computeCategoryHref"
 				/>
 			</aside>

--- a/apps/romainlanz.com/inertia/pages/articles/list.vue
+++ b/apps/romainlanz.com/inertia/pages/articles/list.vue
@@ -34,11 +34,11 @@
 	}
 
 	function computeAllCategoriesHref() {
-		return client.urlFor('articles.index', undefined, { qs: { tag: activeTag } });
+		return client.urlFor('articles.index');
 	}
 
 	function computeCategoryHref(category: { slug: string }) {
-		return client.urlFor('articles.index', undefined, { qs: { category: category.slug, tag: activeTag } });
+		return client.urlFor('articles.index', undefined, { qs: { category: category.slug } });
 	}
 
 	function computeArticleHref(slug: string) {

--- a/apps/romainlanz.com/package.json
+++ b/apps/romainlanz.com/package.json
@@ -88,6 +88,7 @@
 		"@adonisjs/assembler": "^8.4.0",
 		"@adonisjs/tsconfig": "^2.0.0",
 		"@faker-js/faker": "^10.4.0",
+		"@japa/api-client": "^3.2.1",
 		"@japa/assert": "^4.0.1",
 		"@japa/plugin-adonisjs": "^5.2.0",
 		"@japa/runner": "^4.2.0",

--- a/apps/romainlanz.com/tests/bootstrap.ts
+++ b/apps/romainlanz.com/tests/bootstrap.ts
@@ -1,5 +1,7 @@
 import app from '@adonisjs/core/services/app';
 import testUtils from '@adonisjs/core/services/test_utils';
+import { inertiaApiClient } from '@adonisjs/inertia/plugins/api_client';
+import { apiClient } from '@japa/api-client';
 import { assert } from '@japa/assert';
 import { pluginAdonisJS } from '@japa/plugin-adonisjs';
 import type { Config } from '@japa/runner/types';
@@ -12,7 +14,7 @@ import type { Config } from '@japa/runner/types';
  * Configure Japa plugins in the plugins array.
  * Learn more - https://japa.dev/docs/runner-config#plugins-optional
  */
-export const plugins: Config['plugins'] = [assert(), pluginAdonisJS(app)];
+export const plugins: Config['plugins'] = [assert(), pluginAdonisJS(app), apiClient(), inertiaApiClient(app)];
 
 /**
  * Configure lifecycle function to run before and after all the

--- a/apps/romainlanz.com/tests/factories/index.ts
+++ b/apps/romainlanz.com/tests/factories/index.ts
@@ -23,12 +23,16 @@ export const AdminFactory = UserFactory.merge({
 	role: UserRole.Admin,
 });
 
-export const CategoryFactory = defineFactory('categories', ({ faker }) => ({
-	id: faker.string.uuid(),
-	name: faker.commerce.department(),
-	slug: faker.helpers.slugify(faker.commerce.department()).toLowerCase(),
-	illustration_name: 'code',
-}));
+export const CategoryFactory = defineFactory('categories', ({ faker, sequence }) => {
+	const name = `${faker.commerce.department()} ${sequence}`;
+
+	return {
+		id: faker.string.uuid(),
+		name,
+		slug: generateSlug(name),
+		illustration_name: 'code',
+	};
+});
 
 export const TagFactory = defineFactory('tags', ({ faker, sequence }) => {
 	const name = faker.word.words({ count: { min: 1, max: 2 } });

--- a/apps/romainlanz.com/tests/fixtures/article_fixture.ts
+++ b/apps/romainlanz.com/tests/fixtures/article_fixture.ts
@@ -1,0 +1,79 @@
+import { ArticleStatus } from '#articles/enums/article_status';
+import { ArticleFactory, CategoryFactory, TagFactory } from '#tests/factories/index';
+import { DatabaseFixture } from '#tests/fixtures/database_fixture';
+import type { FactoryInsert, FactoryRelationValue, FactoryRow } from '#tests/factories/index';
+import type { ApiClient } from '@japa/api-client';
+import type { Assert } from '@japa/assert';
+
+type ArticleOverrides = Omit<Partial<FactoryInsert<'articles'>>, 'published_at' | 'status'>;
+
+type ArticleListPageProps = {
+	activeCategory: string | null;
+	activeTag: string | null;
+	activePage: number;
+	categoryListingAllArticlesCount: number;
+	paginationArticlesCount: number;
+	vm: {
+		articles: Array<{ title: string; slug: string }>;
+	};
+};
+
+type PublishedArticleInput = ArticleOverrides & {
+	category?: FactoryRelationValue<'categories'>;
+	tags?: FactoryRelationValue<'tags'> | FactoryRelationValue<'tags'>[];
+	publishedAt?: Date;
+};
+
+export class ArticleFixture extends DatabaseFixture {
+	async visitArticles(client: ApiClient, query: Record<string, string | number> = {}) {
+		const response = await client.get('/articles').qs(query).withInertia();
+
+		response.assertStatus(200);
+		response.assertInertiaComponent('articles/list');
+
+		return response.inertiaProps as ArticleListPageProps;
+	}
+
+	assertArticleTitles(assert: Assert, props: ArticleListPageProps, expectedTitles: string[]) {
+		assert.deepEqual(
+			props.vm.articles.map((article) => article.title),
+			expectedTitles,
+		);
+	}
+
+	givenCategory(input: Partial<FactoryInsert<'categories'>> = {}) {
+		return CategoryFactory.create(input);
+	}
+
+	givenTag(input: Partial<FactoryInsert<'tags'>> = {}) {
+		return TagFactory.create(input);
+	}
+
+	async givenPublishedArticles(inputs: PublishedArticleInput[]) {
+		const articles: FactoryRow<'articles'>[] = [];
+
+		for (const input of inputs) {
+			articles.push(await this.givenPublishedArticle(input));
+		}
+
+		return articles;
+	}
+
+	async givenPublishedArticle(input: PublishedArticleInput = {}) {
+		const { category, tags, publishedAt, ...attributes } = input;
+		const articleAttributes = {
+			...attributes,
+			published_at: publishedAt ?? new Date('2026-01-01T00:00:00.000Z'),
+			status: ArticleStatus.Public,
+		};
+
+		let factory = category ? ArticleFactory.for('category', category) : ArticleFactory;
+		const articleTags = Array.isArray(tags) ? tags : tags ? [tags] : [];
+
+		for (const articleTag of articleTags) {
+			factory = factory.with('tags', articleTag);
+		}
+
+		return factory.create(articleAttributes);
+	}
+}

--- a/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
+++ b/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
@@ -62,7 +62,7 @@ test.group('List articles filters', (group) => {
 		fixture.assertArticleTitles(assert, props, ['Adonis article']);
 		assert.equal(props.activeCategory, null);
 		assert.equal(props.activeTag, 'adonis');
-		assert.equal(props.categoryListingAllArticlesCount, 1);
+		assert.equal(props.categoryListingAllArticlesCount, 2);
 		assert.equal(props.paginationArticlesCount, 1);
 	});
 
@@ -82,7 +82,7 @@ test.group('List articles filters', (group) => {
 		fixture.assertArticleTitles(assert, props, ['Backend Adonis']);
 		assert.equal(props.activeCategory, 'backend');
 		assert.equal(props.activeTag, 'adonis');
-		assert.equal(props.categoryListingAllArticlesCount, 2);
+		assert.equal(props.categoryListingAllArticlesCount, 3);
 		assert.equal(props.paginationArticlesCount, 1);
 	});
 
@@ -115,7 +115,7 @@ test.group('List articles filters', (group) => {
 		assert.equal(props.activeCategory, 'backend');
 		assert.equal(props.activeTag, 'adonis');
 		assert.equal(props.activePage, 2);
-		assert.equal(props.categoryListingAllArticlesCount, 6);
+		assert.equal(props.categoryListingAllArticlesCount, 7);
 		assert.equal(props.paginationArticlesCount, 5);
 	});
 

--- a/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
+++ b/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
@@ -1,0 +1,121 @@
+import { test } from '@japa/runner';
+import { ArticleFixture } from '#tests/fixtures/article_fixture';
+
+test.group('List articles filters', (group) => {
+	let fixture: ArticleFixture;
+
+	group.each.setup(async () => {
+		fixture = new ArticleFixture();
+		await fixture.resetDatabase();
+	});
+
+	test('lists published articles without filters', async ({ client, assert }) => {
+		await fixture.givenPublishedArticles([
+			{
+				title: 'Adonis article',
+				slug: 'adonis-article',
+				publishedAt: new Date('2026-01-01T00:00:00.000Z'),
+			},
+			{
+				title: 'Vue article',
+				slug: 'vue-article',
+				publishedAt: new Date('2026-01-02T00:00:00.000Z'),
+			},
+		]);
+
+		const props = await fixture.visitArticles(client);
+
+		fixture.assertArticleTitles(assert, props, ['Vue article', 'Adonis article']);
+		assert.equal(props.activeCategory, null);
+		assert.equal(props.activeTag, null);
+		assert.equal(props.categoryListingAllArticlesCount, 2);
+		assert.equal(props.paginationArticlesCount, 2);
+	});
+
+	test('filters published articles by category', async ({ client, assert }) => {
+		const backend = await fixture.givenCategory({ name: 'Backend', slug: 'backend' });
+		const frontend = await fixture.givenCategory({ name: 'Frontend', slug: 'frontend' });
+		await fixture.givenPublishedArticles([
+			{ title: 'Adonis article', slug: 'adonis-article', category: backend },
+			{ title: 'Vue article', slug: 'vue-article', category: frontend },
+		]);
+
+		const props = await fixture.visitArticles(client, { category: 'backend' });
+
+		fixture.assertArticleTitles(assert, props, ['Adonis article']);
+		assert.equal(props.activeCategory, 'backend');
+		assert.equal(props.activeTag, null);
+		assert.equal(props.categoryListingAllArticlesCount, 2);
+		assert.equal(props.paginationArticlesCount, 1);
+	});
+
+	test('filters published articles by tag', async ({ client, assert }) => {
+		const adonis = await fixture.givenTag({ name: 'Adonis', slug: 'adonis', color: 'cyan' });
+		const vue = await fixture.givenTag({ name: 'Vue', slug: 'vue', color: 'lime' });
+		await fixture.givenPublishedArticles([
+			{ title: 'Adonis article', slug: 'adonis-article', tags: adonis },
+			{ title: 'Vue article', slug: 'vue-article', tags: vue },
+		]);
+
+		const props = await fixture.visitArticles(client, { tag: 'adonis' });
+
+		fixture.assertArticleTitles(assert, props, ['Adonis article']);
+		assert.equal(props.activeCategory, null);
+		assert.equal(props.activeTag, 'adonis');
+		assert.equal(props.categoryListingAllArticlesCount, 1);
+		assert.equal(props.paginationArticlesCount, 1);
+	});
+
+	test('combines category and tag filters with AND logic', async ({ client, assert }) => {
+		const backend = await fixture.givenCategory({ name: 'Backend', slug: 'backend' });
+		const frontend = await fixture.givenCategory({ name: 'Frontend', slug: 'frontend' });
+		const adonis = await fixture.givenTag({ name: 'Adonis', slug: 'adonis', color: 'cyan' });
+		const vue = await fixture.givenTag({ name: 'Vue', slug: 'vue', color: 'lime' });
+		await fixture.givenPublishedArticles([
+			{ title: 'Backend Adonis', slug: 'backend-adonis', category: backend, tags: adonis },
+			{ title: 'Frontend Adonis', slug: 'frontend-adonis', category: frontend, tags: adonis },
+			{ title: 'Backend Vue', slug: 'backend-vue', category: backend, tags: vue },
+		]);
+
+		const props = await fixture.visitArticles(client, { category: 'backend', tag: 'adonis' });
+
+		fixture.assertArticleTitles(assert, props, ['Backend Adonis']);
+		assert.equal(props.activeCategory, 'backend');
+		assert.equal(props.activeTag, 'adonis');
+		assert.equal(props.categoryListingAllArticlesCount, 2);
+		assert.equal(props.paginationArticlesCount, 1);
+	});
+
+	test('returns not found for an unknown tag', async ({ client }) => {
+		const response = await client.get('/articles').qs({ tag: 'unknown-tag' }).withInertia();
+
+		response.assertStatus(404);
+	});
+
+	test('keeps category and tag filters while paginating', async ({ client, assert }) => {
+		const backend = await fixture.givenCategory({ name: 'Backend', slug: 'backend' });
+		const frontend = await fixture.givenCategory({ name: 'Frontend', slug: 'frontend' });
+		const adonis = await fixture.givenTag({ name: 'Adonis', slug: 'adonis', color: 'cyan' });
+		const vue = await fixture.givenTag({ name: 'Vue', slug: 'vue', color: 'lime' });
+		await fixture.givenPublishedArticles([
+			...Array.from({ length: 5 }, (_, index) => ({
+				title: `Backend Adonis ${index + 1}`,
+				slug: `backend-adonis-${index + 1}`,
+				category: backend,
+				tags: adonis,
+				publishedAt: new Date(`2026-01-0${index + 1}T00:00:00.000Z`),
+			})),
+			{ title: 'Frontend Adonis', slug: 'frontend-adonis', category: frontend, tags: adonis },
+			{ title: 'Backend Vue', slug: 'backend-vue', category: backend, tags: vue },
+		]);
+
+		const props = await fixture.visitArticles(client, { category: 'backend', tag: 'adonis', page: 2 });
+
+		fixture.assertArticleTitles(assert, props, ['Backend Adonis 1']);
+		assert.equal(props.activeCategory, 'backend');
+		assert.equal(props.activeTag, 'adonis');
+		assert.equal(props.activePage, 2);
+		assert.equal(props.categoryListingAllArticlesCount, 6);
+		assert.equal(props.paginationArticlesCount, 5);
+	});
+});

--- a/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
+++ b/apps/romainlanz.com/tests/functional/articles/list_articles_filter.spec.ts
@@ -118,4 +118,19 @@ test.group('List articles filters', (group) => {
 		assert.equal(props.categoryListingAllArticlesCount, 6);
 		assert.equal(props.paginationArticlesCount, 5);
 	});
+
+	test('category navigation clears the active tag filter', async ({ client, assert }) => {
+		const backend = await fixture.givenCategory({ name: 'Backend', slug: 'backend' });
+		const adonis = await fixture.givenTag({ name: 'Adonis', slug: 'adonis', color: 'cyan' });
+		await fixture.givenPublishedArticles([
+			{ title: 'Backend Adonis', slug: 'backend-adonis', category: backend, tags: adonis },
+		]);
+
+		const response = await client.get('/articles').qs({ tag: 'adonis' });
+
+		response.assertStatus(200);
+		assert.include(response.text(), '/articles?category=backend');
+		assert.notInclude(response.text(), 'href="/articles?category=backend&amp;tag=adonis"');
+		assert.notInclude(response.text(), 'href="/articles?tag=adonis&amp;category=backend"');
+	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,6 +1899,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@japa/api-client@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "@japa/api-client@npm:3.2.1"
+  dependencies:
+    "@poppinss/hooks": "npm:^7.3.0"
+    "@poppinss/macroable": "npm:^1.1.0"
+    "@poppinss/qs": "npm:^6.15.0"
+    "@types/superagent": "npm:^8.1.9"
+    cookie-es: "npm:^2.0.0"
+    set-cookie-parser: "npm:^2.7.2"
+    superagent: "npm:^10.3.0"
+  peerDependencies:
+    "@japa/assert": ^2.0.0 || ^3.0.0 || ^4.0.0
+    "@japa/openapi-assertions": ^0.1.1
+    "@japa/runner": ^3.1.2 || ^4.0.0 || ^5.0.0
+  peerDependenciesMeta:
+    "@japa/assert":
+      optional: true
+    "@japa/openapi-assertions":
+      optional: true
+  checksum: 10c0/1751cb4b580473feed9118c7c35ad4b1ee3744e4d99bbe446a447cb8dd8fd34105a7c9f36993b282820f28a07217e1da841134a06f1eecb626589ecc52c80ab9
+  languageName: node
+  linkType: hard
+
 "@japa/assert@npm:^4.0.1":
   version: 4.0.1
   resolution: "@japa/assert@npm:4.0.1"
@@ -3022,6 +3046,7 @@ __metadata:
     "@faker-js/faker": "npm:^10.4.0"
     "@formkit/auto-animate": "npm:^0.8.2"
     "@inertiajs/vue3": "catalog:"
+    "@japa/api-client": "npm:^3.2.1"
     "@japa/assert": "npm:^4.0.1"
     "@japa/plugin-adonisjs": "npm:^5.2.0"
     "@japa/runner": "npm:^4.2.0"
@@ -3935,6 +3960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookiejar@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@types/cookiejar@npm:2.1.5"
+  checksum: 10c0/af38c3d84aebb3ccc6e46fb6afeeaac80fb26e63a487dd4db5a8b87e6ad3d4b845ba1116b2ae90d6f886290a36200fa433d8b1f6fe19c47da6b81872ce9a2764
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -4010,6 +4042,13 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
+  languageName: node
+  linkType: hard
+
+"@types/methods@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@types/methods@npm:1.1.4"
+  checksum: 10c0/a78534d79c300718298bfff92facd07bf38429c66191f640c1db4c9cff1e36f819304298a96f7536b6512bfc398e5c3e6b831405e138cd774b88ad7be78d682a
   languageName: node
   linkType: hard
 
@@ -4092,6 +4131,18 @@ __metadata:
   version: 0.2.33
   resolution: "@types/relateurl@npm:0.2.33"
   checksum: 10c0/6b6aafe9ed59bf674703555d9fbd3d54c4f27eab3b2abed8faa750ca8b93d883727e111948d3537e6429b43c0990a734525a1aed1baf4c51aebc4f69e3f3fb9f
+  languageName: node
+  linkType: hard
+
+"@types/superagent@npm:^8.1.9":
+  version: 8.1.10
+  resolution: "@types/superagent@npm:8.1.10"
+  dependencies:
+    "@types/cookiejar": "npm:^2.1.5"
+    "@types/methods": "npm:^1.1.4"
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/cd911f7e926aae3f23caeebac055c46c5a63576561548356e0ca809147b372a27359112e02a569d527fd677cd90ee6d018b5cdf509a0a5ac70f74289bd29c9bc
   languageName: node
   linkType: hard
 
@@ -5564,7 +5615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asap@npm:~2.0.3":
+"asap@npm:^2.0.0, asap@npm:~2.0.3":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
   checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
@@ -6278,6 +6329,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"component-emitter@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "component-emitter@npm:1.3.1"
+  checksum: 10c0/e4900b1b790b5e76b8d71b328da41482118c0f3523a516a41be598dc2785a07fd721098d9bf6e22d89b19f4fa4e1025160dc00317ea111633a3e4f75c2b86032
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -6333,6 +6391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-es@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "cookie-es@npm:2.0.1"
+  checksum: 10c0/15f904e412dc31f029e90073d3c29456d0baa2aafefa36acad592fe4018b52cddf2cb19860d7d4d67dde3722cd5fc55cdc83a66c1bb56550901ba1b5ce11f4f1
+  languageName: node
+  linkType: hard
+
 "cookie-es@npm:^3.0.1, cookie-es@npm:^3.1.1":
   version: 3.1.1
   resolution: "cookie-es@npm:3.1.1"
@@ -6344,6 +6409,13 @@ __metadata:
   version: 1.0.2
   resolution: "cookie@npm:1.0.2"
   checksum: 10c0/fd25fe79e8fbcfcaf6aa61cd081c55d144eeeba755206c058682257cb38c4bd6795c6620de3f064c740695bb65b7949ebb1db7a95e4636efb8357a335ad3f54b
+  languageName: node
+  linkType: hard
+
+"cookiejar@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "cookiejar@npm:2.1.4"
+  checksum: 10c0/2dae55611c6e1678f34d93984cbd4bda58f4fe3e5247cc4993f4a305cd19c913bbaf325086ed952e892108115073a747596453d3dc1c34947f47f731818b8ad1
   languageName: node
   linkType: hard
 
@@ -6594,7 +6666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.4.3":
+"debug@npm:^4.3.7, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -6713,6 +6785,16 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
+  languageName: node
+  linkType: hard
+
+"dezalgo@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "dezalgo@npm:1.0.4"
+  dependencies:
+    asap: "npm:^2.0.0"
+    wrappy: "npm:1"
+  checksum: 10c0/8a870ed42eade9a397e6141fe5c025148a59ed52f1f28b1db5de216b4d57f0af7a257070c3af7ce3d5508c1ce9dd5009028a76f4b2cc9370dc56551d2355fad8
   languageName: node
   linkType: hard
 
@@ -7518,7 +7600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -7528,6 +7610,17 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+  languageName: node
+  linkType: hard
+
+"formidable@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "formidable@npm:3.5.4"
+  dependencies:
+    "@paralleldrive/cuid2": "npm:^2.2.2"
+    dezalgo: "npm:^1.0.4"
+    once: "npm:^1.4.0"
+  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
   languageName: node
   linkType: hard
 
@@ -9254,6 +9347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"methods@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "methods@npm:1.1.2"
+  checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
+  languageName: node
+  linkType: hard
+
 "micro-memoize@npm:^5.1.1":
   version: 5.1.1
   resolution: "micro-memoize@npm:5.1.1"
@@ -9644,7 +9744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:^2.4.6":
+"mime@npm:2.6.0, mime@npm:^2.4.6":
   version: 2.6.0
   resolution: "mime@npm:2.6.0"
   bin:
@@ -11786,7 +11886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.15.0":
+"qs@npm:^6.14.1, qs@npm:^6.15.0":
   version: 6.15.2
   resolution: "qs@npm:6.15.2"
   dependencies:
@@ -12348,6 +12448,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-cookie-parser@npm:^2.7.2":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
+  languageName: node
+  linkType: hard
+
 "setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
@@ -12893,6 +13000,23 @@ __metadata:
   peerDependencies:
     postcss: ^8.5.13
   checksum: 10c0/6464a08f45ae720b6e6b6c4a04a0c45d6297b5dbcc3432afd79c2e40c868f3ae62046b0faddf712189ad0ea6f0262bb99b828f830e6c9225ee28a6c58f9e4f06
+  languageName: node
+  linkType: hard
+
+"superagent@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "superagent@npm:10.3.0"
+  dependencies:
+    component-emitter: "npm:^1.3.1"
+    cookiejar: "npm:^2.1.4"
+    debug: "npm:^4.3.7"
+    fast-safe-stringify: "npm:^2.1.1"
+    form-data: "npm:^4.0.5"
+    formidable: "npm:^3.5.4"
+    methods: "npm:^1.1.2"
+    mime: "npm:2.6.0"
+    qs: "npm:^6.14.1"
+  checksum: 10c0/7792ec2ba3a877eb1db57ad9149bf0e108688a40af0e75084bdc4bba82604b7962248267159565be4f5ab8aa392f1285a08d2e5a8cb2c3b0a51932499caf6ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Résumé

- ajoute le filtre public des articles par tag via `?tag=<slug>`
- combine les filtres catégorie et tag en logique `AND`
- conserve les filtres actifs dans les liens de catégorie et la pagination
- ajoute des tests fonctionnels Inertia pour les cas attendus de l'issue #47

## Détails

Le comptage de pagination utilise les filtres actifs complets, tandis que le compteur du lien `All` des catégories suit le même contrat que son URL: il conserve le tag actif mais retire la catégorie active.

La fixture article expose des primitives composables (`givenCategory`, `givenTag`, `givenPublishedArticle`, `givenPublishedArticles`) et laisse les factories remplir les données non pertinentes au scénario.

## Validation

- `yarn format`
- `yarn workspace @rlanz/site typecheck`
- `yarn workspace @rlanz/site test functional`
- `yarn lint` avec warnings préexistants