### PR TITLE
[codex] Gérer les tags dans l’admin Taxonomies

### DIFF
--- a/apps/romainlanz.com/.adonisjs/client/data.d.ts
+++ b/apps/romainlanz.com/.adonisjs/client/data.d.ts
@@ -6,40 +6,18 @@
 /// <reference path="./manifest.d.ts" />
 import type { InferData, InferVariants } from '@adonisjs/core/types/transformers'
 import type { InferSharedProps } from '@adonisjs/inertia/types'
-import type ArticlesArticlePageTransformer from '#app/articles/transformers/article_page_transformer'
-import type ArticlesArticleListPageTransformer from '#app/articles/transformers/article_list_page_transformer'
-import type PagesLandingPageTransformer from '#app/pages/transformers/landing_page_transformer'
-import type PastePastePageTransformer from '#app/paste/transformers/paste_page_transformer'
 import type AdminArticlesAdminArticleIndexTransformer from '#app/admin/articles/transformers/admin_article_index_transformer'
 import type AdminRedirectsAdminRedirectIndexTransformer from '#app/admin/redirects/transformers/admin_redirect_index_transformer'
 import type AdminTaxonomiesAdminTaxonomyIndexTransformer from '#app/admin/taxonomies/transformers/admin_taxonomy_index_transformer'
-import type TaxonomiesCategoryOptionTransformer from '#app/taxonomies/transformers/category_option_transformer'
+import type ArticlesArticleListPageTransformer from '#app/articles/transformers/article_list_page_transformer'
+import type ArticlesArticlePageTransformer from '#app/articles/transformers/article_page_transformer'
 import type AuthCurrentUserTransformer from '#app/auth/transformers/current_user_transformer'
+import type PagesLandingPageTransformer from '#app/pages/transformers/landing_page_transformer'
+import type PastePastePageTransformer from '#app/paste/transformers/paste_page_transformer'
+import type TaxonomiesCategoryOptionTransformer from '#app/taxonomies/transformers/category_option_transformer'
 import type InertiaMiddleware from '#middleware/inertia_middleware'
 
 export namespace Data {
-  export namespace Articles {
-    export type ArticlePage = InferData<ArticlesArticlePageTransformer>
-    export namespace ArticlePage {
-      export type Variants = InferVariants<ArticlesArticlePageTransformer>
-    }
-    export type ArticleListPage = InferData<ArticlesArticleListPageTransformer>
-    export namespace ArticleListPage {
-      export type Variants = InferVariants<ArticlesArticleListPageTransformer>
-    }
-  }
-  export namespace Pages {
-    export type LandingPage = InferData<PagesLandingPageTransformer>
-    export namespace LandingPage {
-      export type Variants = InferVariants<PagesLandingPageTransformer>
-    }
-  }
-  export namespace Paste {
-    export type PastePage = InferData<PastePastePageTransformer>
-    export namespace PastePage {
-      export type Variants = InferVariants<PastePastePageTransformer>
-    }
-  }
   export namespace Admin {
     export namespace Articles {
       export type AdminArticleIndex = InferData<AdminArticlesAdminArticleIndexTransformer>
@@ -60,16 +38,38 @@ export namespace Data {
       }
     }
   }
-  export namespace Taxonomies {
-    export type CategoryOption = InferData<TaxonomiesCategoryOptionTransformer>
-    export namespace CategoryOption {
-      export type Variants = InferVariants<TaxonomiesCategoryOptionTransformer>
+  export namespace Articles {
+    export type ArticleListPage = InferData<ArticlesArticleListPageTransformer>
+    export namespace ArticleListPage {
+      export type Variants = InferVariants<ArticlesArticleListPageTransformer>
+    }
+    export type ArticlePage = InferData<ArticlesArticlePageTransformer>
+    export namespace ArticlePage {
+      export type Variants = InferVariants<ArticlesArticlePageTransformer>
     }
   }
   export namespace Auth {
     export type CurrentUser = InferData<AuthCurrentUserTransformer>
     export namespace CurrentUser {
       export type Variants = InferVariants<AuthCurrentUserTransformer>
+    }
+  }
+  export namespace Pages {
+    export type LandingPage = InferData<PagesLandingPageTransformer>
+    export namespace LandingPage {
+      export type Variants = InferVariants<PagesLandingPageTransformer>
+    }
+  }
+  export namespace Paste {
+    export type PastePage = InferData<PastePastePageTransformer>
+    export namespace PastePage {
+      export type Variants = InferVariants<PastePastePageTransformer>
+    }
+  }
+  export namespace Taxonomies {
+    export type CategoryOption = InferData<TaxonomiesCategoryOptionTransformer>
+    export namespace CategoryOption {
+      export type Variants = InferVariants<TaxonomiesCategoryOptionTransformer>
     }
   }
   export type SharedProps = InferSharedProps<InertiaMiddleware>

--- a/apps/romainlanz.com/.adonisjs/client/registry/index.ts
+++ b/apps/romainlanz.com/.adonisjs/client/registry/index.ts
@@ -96,6 +96,18 @@ const routes = {
     tokens: [{"old":"/admin/taxonomies/categories","type":0,"val":"admin","end":""},{"old":"/admin/taxonomies/categories","type":0,"val":"taxonomies","end":""},{"old":"/admin/taxonomies/categories","type":0,"val":"categories","end":""}],
     types: placeholder as Registry['admin.taxonomies.categories.store']['types'],
   },
+  'admin.taxonomies.tags.create': {
+    methods: ["GET","HEAD"],
+    pattern: '/admin/taxonomies/tags/create',
+    tokens: [{"old":"/admin/taxonomies/tags/create","type":0,"val":"admin","end":""},{"old":"/admin/taxonomies/tags/create","type":0,"val":"taxonomies","end":""},{"old":"/admin/taxonomies/tags/create","type":0,"val":"tags","end":""},{"old":"/admin/taxonomies/tags/create","type":0,"val":"create","end":""}],
+    types: placeholder as Registry['admin.taxonomies.tags.create']['types'],
+  },
+  'admin.taxonomies.tags.store': {
+    methods: ["POST"],
+    pattern: '/admin/taxonomies/tags',
+    tokens: [{"old":"/admin/taxonomies/tags","type":0,"val":"admin","end":""},{"old":"/admin/taxonomies/tags","type":0,"val":"taxonomies","end":""},{"old":"/admin/taxonomies/tags","type":0,"val":"tags","end":""}],
+    types: placeholder as Registry['admin.taxonomies.tags.store']['types'],
+  },
   'pages.landing': {
     methods: ["GET","HEAD"],
     pattern: '/',

--- a/apps/romainlanz.com/.adonisjs/client/registry/schema.d.ts
+++ b/apps/romainlanz.com/.adonisjs/client/registry/schema.d.ts
@@ -15,8 +15,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#twitch/controllers/get_live_status_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#twitch/controllers/get_live_status_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/twitch/controllers/get_live_status_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/twitch/controllers/get_live_status_controller').default['render']>>>
     }
   }
   'admin.pages.dashboard': {
@@ -27,8 +27,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/pages/controllers/pages_controller').default['dashboard']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/pages/controllers/pages_controller').default['dashboard']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/pages/controllers/pages_controller').default['dashboard']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/pages/controllers/pages_controller').default['dashboard']>>>
     }
   }
   'admin.og.preview': {
@@ -38,9 +38,9 @@ export interface Registry {
       body: {}
       paramsTuple: []
       params: {}
-      query: ExtractQueryForGet<InferInput<(typeof import('#common/controllers/compute_og_image_controllers').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#common/controllers/compute_og_image_controllers').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#common/controllers/compute_og_image_controllers').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQueryForGet<InferInput<(typeof import('#app/admin/articles/controllers/preview_og_image_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/preview_og_image_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/preview_og_image_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'admin.articles.index': {
@@ -51,8 +51,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/articles/controllers/list_articles_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/articles/controllers/list_articles_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/list_articles_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/list_articles_controller').default['render']>>>
     }
   }
   'admin.articles.create': {
@@ -63,20 +63,20 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/articles/controllers/store_article_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/articles/controllers/store_article_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/store_article_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/store_article_controller').default['render']>>>
     }
   }
   'admin.articles.store': {
     methods: ["POST"]
     pattern: '/admin/articles'
     types: {
-      body: ExtractBody<InferInput<(typeof import('#admin/articles/controllers/store_article_controller').default)['validator']>>
+      body: ExtractBody<InferInput<(typeof import('#app/admin/articles/controllers/store_article_controller').default)['validator']>>
       paramsTuple: []
       params: {}
-      query: ExtractQuery<InferInput<(typeof import('#admin/articles/controllers/store_article_controller').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/articles/controllers/store_article_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/articles/controllers/store_article_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQuery<InferInput<(typeof import('#app/admin/articles/controllers/store_article_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/store_article_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/store_article_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'admin.articles.edit': {
@@ -87,20 +87,20 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { id: ParamValue }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/articles/controllers/update_article_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/articles/controllers/update_article_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/update_article_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/update_article_controller').default['render']>>>
     }
   }
   'admin.articles.update': {
     methods: ["PUT"]
     pattern: '/admin/articles/:id'
     types: {
-      body: ExtractBody<InferInput<(typeof import('#admin/articles/controllers/update_article_controller').default)['validator']>>
+      body: ExtractBody<InferInput<(typeof import('#app/admin/articles/controllers/update_article_controller').default)['validator']>>
       paramsTuple: [ParamValue]
       params: { id: ParamValue }
-      query: ExtractQuery<InferInput<(typeof import('#admin/articles/controllers/update_article_controller').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/articles/controllers/update_article_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/articles/controllers/update_article_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQuery<InferInput<(typeof import('#app/admin/articles/controllers/update_article_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/update_article_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/articles/controllers/update_article_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'admin.redirects.index': {
@@ -111,8 +111,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/redirects/controllers/list_redirects_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/redirects/controllers/list_redirects_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/list_redirects_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/list_redirects_controller').default['render']>>>
     }
   }
   'admin.redirects.create': {
@@ -123,20 +123,20 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/redirects/controllers/store_redirect_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/redirects/controllers/store_redirect_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/store_redirect_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/store_redirect_controller').default['render']>>>
     }
   }
   'admin.redirects.store': {
     methods: ["POST"]
     pattern: '/admin/redirects'
     types: {
-      body: ExtractBody<InferInput<(typeof import('#admin/redirects/controllers/store_redirect_controller').default)['validator']>>
+      body: ExtractBody<InferInput<(typeof import('#app/admin/redirects/controllers/store_redirect_controller').default)['validator']>>
       paramsTuple: []
       params: {}
-      query: ExtractQuery<InferInput<(typeof import('#admin/redirects/controllers/store_redirect_controller').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/redirects/controllers/store_redirect_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/redirects/controllers/store_redirect_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQuery<InferInput<(typeof import('#app/admin/redirects/controllers/store_redirect_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/store_redirect_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/store_redirect_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'admin.redirects.delete': {
@@ -147,8 +147,8 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { id: ParamValue }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/redirects/controllers/delete_redirect_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/redirects/controllers/delete_redirect_controller').default['execute']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/delete_redirect_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/redirects/controllers/delete_redirect_controller').default['execute']>>>
     }
   }
   'admin.taxonomies.index': {
@@ -159,8 +159,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/list_taxonomies_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/list_taxonomies_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/list_taxonomies_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/list_taxonomies_controller').default['render']>>>
     }
   }
   'admin.taxonomies.categories.create': {
@@ -171,8 +171,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/store_category_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/store_category_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_category_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_category_controller').default['render']>>>
     }
   }
   'admin.taxonomies.categories.store': {
@@ -183,8 +183,32 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/store_category_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#admin/taxonomies/controllers/store_category_controller').default['execute']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_category_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_category_controller').default['execute']>>>
+    }
+  }
+  'admin.taxonomies.tags.create': {
+    methods: ["GET","HEAD"]
+    pattern: '/admin/taxonomies/tags/create'
+    types: {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_tag_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_tag_controller').default['render']>>>
+    }
+  }
+  'admin.taxonomies.tags.store': {
+    methods: ["POST"]
+    pattern: '/admin/taxonomies/tags'
+    types: {
+      body: ExtractBody<InferInput<(typeof import('#app/admin/taxonomies/controllers/store_tag_controller').default)['validator']>>
+      paramsTuple: []
+      params: {}
+      query: ExtractQuery<InferInput<(typeof import('#app/admin/taxonomies/controllers/store_tag_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_tag_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/admin/taxonomies/controllers/store_tag_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'pages.landing': {
@@ -195,8 +219,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#pages/controllers/landing_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#pages/controllers/landing_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/pages/controllers/landing_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/pages/controllers/landing_controller').default['render']>>>
     }
   }
   'articles.index': {
@@ -207,8 +231,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#articles/controllers/list_articles_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#articles/controllers/list_articles_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/articles/controllers/list_articles_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/articles/controllers/list_articles_controller').default['render']>>>
     }
   }
   'articles.og': {
@@ -219,8 +243,8 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { slug: ParamValue }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#articles/controllers/show_article_og_image_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#articles/controllers/show_article_og_image_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/articles/controllers/show_article_og_image_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/articles/controllers/show_article_og_image_controller').default['render']>>>
     }
   }
   'articles.show': {
@@ -231,8 +255,8 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { slug: ParamValue }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#articles/controllers/show_article_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#articles/controllers/show_article_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/articles/controllers/show_article_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/articles/controllers/show_article_controller').default['render']>>>
     }
   }
   'pages.contact': {
@@ -243,20 +267,20 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#pages/controllers/contact_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#pages/controllers/contact_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/pages/controllers/contact_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/pages/controllers/contact_controller').default['render']>>>
     }
   }
   'pages.contact.store': {
     methods: ["POST"]
     pattern: '/contact'
     types: {
-      body: ExtractBody<InferInput<(typeof import('#pages/controllers/contact_controller').default)['validator']>>
+      body: ExtractBody<InferInput<(typeof import('#app/pages/controllers/contact_controller').default)['validator']>>
       paramsTuple: []
       params: {}
-      query: ExtractQuery<InferInput<(typeof import('#pages/controllers/contact_controller').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#pages/controllers/contact_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#pages/controllers/contact_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQuery<InferInput<(typeof import('#app/pages/controllers/contact_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/pages/controllers/contact_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/pages/controllers/contact_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'pages.about': {
@@ -267,8 +291,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#pages/controllers/about_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#pages/controllers/about_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/pages/controllers/about_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/pages/controllers/about_controller').default['render']>>>
     }
   }
   'auth.login': {
@@ -279,8 +303,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#auth/controllers/login_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#auth/controllers/login_controller').default['execute']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/auth/controllers/login_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/auth/controllers/login_controller').default['execute']>>>
     }
   }
   'auth.logout': {
@@ -291,8 +315,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#auth/controllers/logout_controller').default['handle']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#auth/controllers/logout_controller').default['handle']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/auth/controllers/logout_controller').default['handle']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/auth/controllers/logout_controller').default['handle']>>>
     }
   }
   'api.assets.store': {
@@ -303,8 +327,8 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#media/controllers/upload_image_controller').default['handle']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#media/controllers/upload_image_controller').default['handle']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/media/controllers/upload_image_controller').default['handle']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/media/controllers/upload_image_controller').default['handle']>>>
     }
   }
   'pastes.create': {
@@ -315,20 +339,20 @@ export interface Registry {
       paramsTuple: []
       params: {}
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#paste/controllers/store_paste_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#paste/controllers/store_paste_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/paste/controllers/store_paste_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/paste/controllers/store_paste_controller').default['render']>>>
     }
   }
   'pastes.store': {
     methods: ["POST"]
     pattern: '/'
     types: {
-      body: ExtractBody<InferInput<(typeof import('#paste/controllers/store_paste_controller').default)['validator']>>
+      body: ExtractBody<InferInput<(typeof import('#app/paste/controllers/store_paste_controller').default)['validator']>>
       paramsTuple: []
       params: {}
-      query: ExtractQuery<InferInput<(typeof import('#paste/controllers/store_paste_controller').default)['validator']>>
-      response: ExtractResponse<Awaited<ReturnType<import('#paste/controllers/store_paste_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#paste/controllers/store_paste_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
+      query: ExtractQuery<InferInput<(typeof import('#app/paste/controllers/store_paste_controller').default)['validator']>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/paste/controllers/store_paste_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/paste/controllers/store_paste_controller').default['execute']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
   'pastes.show': {
@@ -339,8 +363,8 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { id: ParamValue }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#paste/controllers/show_paste_controller').default['render']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#paste/controllers/show_paste_controller').default['render']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/paste/controllers/show_paste_controller').default['render']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/paste/controllers/show_paste_controller').default['render']>>>
     }
   }
   'process_redirect.execute': {
@@ -351,8 +375,8 @@ export interface Registry {
       paramsTuple: [ParamValue]
       params: { '*': ParamValue[] }
       query: {}
-      response: ExtractResponse<Awaited<ReturnType<import('#redirects/controllers/process_redirect_controller').default['execute']>>>
-      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#redirects/controllers/process_redirect_controller').default['execute']>>>
+      response: ExtractResponse<Awaited<ReturnType<import('#app/redirects/controllers/process_redirect_controller').default['execute']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#app/redirects/controllers/process_redirect_controller').default['execute']>>>
     }
   }
 }

--- a/apps/romainlanz.com/.adonisjs/client/registry/tree.d.ts
+++ b/apps/romainlanz.com/.adonisjs/client/registry/tree.d.ts
@@ -31,6 +31,10 @@ export interface ApiDefinition {
         create: typeof routes['admin.taxonomies.categories.create']
         store: typeof routes['admin.taxonomies.categories.store']
       }
+      tags: {
+        create: typeof routes['admin.taxonomies.tags.create']
+        store: typeof routes['admin.taxonomies.tags.store']
+      }
     }
   }
   pages: {

--- a/apps/romainlanz.com/.adonisjs/server/controllers.ts
+++ b/apps/romainlanz.com/.adonisjs/server/controllers.ts
@@ -7,9 +7,9 @@ export const controllers = {
   admin: {
     articles: {
       ListArticles: () => import('#app/admin/articles/controllers/list_articles_controller'),
+      PreviewOgImage: () => import('#app/admin/articles/controllers/preview_og_image_controller'),
       StoreArticle: () => import('#app/admin/articles/controllers/store_article_controller'),
       UpdateArticle: () => import('#app/admin/articles/controllers/update_article_controller'),
-      PreviewOgImage: () => import('#app/admin/articles/controllers/preview_og_image_controller'),
     },
     pages: {
       Pages: () => import('#app/admin/pages/controllers/pages_controller'),
@@ -22,6 +22,7 @@ export const controllers = {
     taxonomies: {
       ListTaxonomies: () => import('#app/admin/taxonomies/controllers/list_taxonomies_controller'),
       StoreCategory: () => import('#app/admin/taxonomies/controllers/store_category_controller'),
+      StoreTag: () => import('#app/admin/taxonomies/controllers/store_tag_controller'),
     },
   },
   articles: {

--- a/apps/romainlanz.com/.adonisjs/server/pages.d.ts
+++ b/apps/romainlanz.com/.adonisjs/server/pages.d.ts
@@ -18,6 +18,7 @@ declare module '@adonisjs/inertia/types' {
     'admin/redirects/list': ExtractProps<(typeof import('../../inertia/pages/admin/redirects/list.vue'))['default']>
     'admin/taxonomies/categories/create': ExtractProps<(typeof import('../../inertia/pages/admin/taxonomies/categories/create.vue'))['default']>
     'admin/taxonomies/list': ExtractProps<(typeof import('../../inertia/pages/admin/taxonomies/list.vue'))['default']>
+    'admin/taxonomies/tags/create': ExtractProps<(typeof import('../../inertia/pages/admin/taxonomies/tags/create.vue'))['default']>
     'articles/list': ExtractProps<(typeof import('../../inertia/pages/articles/list.vue'))['default']>
     'articles/show': ExtractProps<(typeof import('../../inertia/pages/articles/show.vue'))['default']>
     'contact': ExtractProps<(typeof import('../../inertia/pages/contact.vue'))['default']>

--- a/apps/romainlanz.com/.adonisjs/server/routes.d.ts
+++ b/apps/romainlanz.com/.adonisjs/server/routes.d.ts
@@ -19,6 +19,8 @@ export type ScannedRoutes = {
     'admin.taxonomies.index': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.categories.create': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.categories.store': { paramsTuple?: []; params?: {} }
+    'admin.taxonomies.tags.create': { paramsTuple?: []; params?: {} }
+    'admin.taxonomies.tags.store': { paramsTuple?: []; params?: {} }
     'pages.landing': { paramsTuple?: []; params?: {} }
     'articles.index': { paramsTuple?: []; params?: {} }
     'articles.og': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
@@ -45,6 +47,7 @@ export type ScannedRoutes = {
     'admin.redirects.create': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.index': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.categories.create': { paramsTuple?: []; params?: {} }
+    'admin.taxonomies.tags.create': { paramsTuple?: []; params?: {} }
     'pages.landing': { paramsTuple?: []; params?: {} }
     'articles.index': { paramsTuple?: []; params?: {} }
     'articles.og': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
@@ -66,6 +69,7 @@ export type ScannedRoutes = {
     'admin.redirects.create': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.index': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.categories.create': { paramsTuple?: []; params?: {} }
+    'admin.taxonomies.tags.create': { paramsTuple?: []; params?: {} }
     'pages.landing': { paramsTuple?: []; params?: {} }
     'articles.index': { paramsTuple?: []; params?: {} }
     'articles.og': { paramsTuple: [ParamValue]; params: {'slug': ParamValue} }
@@ -80,6 +84,7 @@ export type ScannedRoutes = {
     'admin.articles.store': { paramsTuple?: []; params?: {} }
     'admin.redirects.store': { paramsTuple?: []; params?: {} }
     'admin.taxonomies.categories.store': { paramsTuple?: []; params?: {} }
+    'admin.taxonomies.tags.store': { paramsTuple?: []; params?: {} }
     'pages.contact.store': { paramsTuple?: []; params?: {} }
     'auth.login': { paramsTuple?: []; params?: {} }
     'api.assets.store': { paramsTuple?: []; params?: {} }

--- a/apps/romainlanz.com/.env.test
+++ b/apps/romainlanz.com/.env.test
@@ -1,0 +1,1 @@
+SESSION_DRIVER=memory

--- a/apps/romainlanz.com/app/admin/taxonomies/controllers/list_taxonomies_controller.ts
+++ b/apps/romainlanz.com/app/admin/taxonomies/controllers/list_taxonomies_controller.ts
@@ -1,17 +1,22 @@
 import { inject } from '@adonisjs/core';
 import AdminTaxonomyIndexTransformer from '#admin/taxonomies/transformers/admin_taxonomy_index_transformer';
 import { ListCategoriesQuery } from '#taxonomies/queries/list_categories_query';
+import { ListTagsQuery } from '#taxonomies/queries/list_tags_query';
 import type { HttpContext } from '@adonisjs/core/http';
 
 @inject()
 export default class ListTaxonomiesController {
-	constructor(private readonly listCategories: ListCategoriesQuery) {}
+	constructor(
+		private readonly listCategories: ListCategoriesQuery,
+		private readonly listTags: ListTagsQuery,
+	) {}
 
 	async render({ inertia }: HttpContext) {
 		const categories = await this.listCategories.execute();
+		const tags = await this.listTags.execute();
 
 		return inertia.render('admin/taxonomies/list', {
-			vm: AdminTaxonomyIndexTransformer.transform({ categories }),
+			vm: AdminTaxonomyIndexTransformer.transform({ categories, tags }),
 		});
 	}
 }

--- a/apps/romainlanz.com/app/admin/taxonomies/controllers/store_tag_controller.ts
+++ b/apps/romainlanz.com/app/admin/taxonomies/controllers/store_tag_controller.ts
@@ -1,0 +1,45 @@
+import { inject } from '@adonisjs/core';
+import { tagColors } from '@rlanz/design-system/tag-color';
+import vine from '@vinejs/vine';
+import { TagRepository, TagSlugAlreadyExistsError } from '#taxonomies/repositories/tag_repository';
+import type { HttpContext } from '@adonisjs/core/http';
+
+@inject()
+export default class StoreTagController {
+	static validator = vine.compile(
+		vine.object({
+			name: vine.string().trim(),
+			slug: vine.string().trim().optional(),
+			color: vine
+				.string()
+				.trim()
+				.in([...tagColors]),
+		}),
+	);
+
+	constructor(private repository: TagRepository) {}
+
+	render({ inertia }: HttpContext) {
+		return inertia.render('admin/taxonomies/tags/create', {});
+	}
+
+	async execute({ request, response, session }: HttpContext) {
+		const payload = await request.validateUsing(StoreTagController.validator);
+
+		try {
+			await this.repository.create(payload);
+		} catch (error) {
+			if (!(error instanceof TagSlugAlreadyExistsError)) {
+				throw error;
+			}
+
+			session.flash('inputErrorsBag', {
+				slug: ['Ce slug est déjà utilisé.'],
+			});
+
+			return response.redirect().toRoute('admin.taxonomies.tags.create');
+		}
+
+		return response.redirect().toRoute('admin.taxonomies.index');
+	}
+}

--- a/apps/romainlanz.com/app/admin/taxonomies/transformers/admin_taxonomy_index_transformer.ts
+++ b/apps/romainlanz.com/app/admin/taxonomies/transformers/admin_taxonomy_index_transformer.ts
@@ -1,8 +1,10 @@
 import { BaseTransformer } from '@adonisjs/core/transformers';
 import type { Category } from '#taxonomies/domain/category';
+import type { Tag } from '#taxonomies/domain/tag';
 
 type AdminTaxonomyIndex = {
 	categories: Category[];
+	tags: Tag[];
 };
 
 export default class AdminTaxonomyIndexTransformer extends BaseTransformer<AdminTaxonomyIndex> {
@@ -12,6 +14,12 @@ export default class AdminTaxonomyIndexTransformer extends BaseTransformer<Admin
 				id: category.getIdentifier().toString(),
 				name: category.props.name,
 				illustrationName: category.props.illustrationName,
+			})),
+			tags: this.resource.tags.map((tag) => ({
+				id: tag.getIdentifier().toString(),
+				name: tag.props.name,
+				slug: tag.props.slug,
+				color: tag.props.color,
 			})),
 		};
 	}

--- a/apps/romainlanz.com/app/taxonomies/repositories/tag_repository.ts
+++ b/apps/romainlanz.com/app/taxonomies/repositories/tag_repository.ts
@@ -8,6 +8,7 @@ import { TagIdentifier } from '#taxonomies/domain/tag_identifier';
 interface CreateTagDTO {
 	name: string;
 	color: string;
+	slug?: string;
 }
 
 interface UpdateTagDTO {
@@ -16,14 +17,17 @@ interface UpdateTagDTO {
 	color: string;
 }
 
+export class TagSlugAlreadyExistsError extends Error {}
+
 export class TagRepository {
 	async create(payload: CreateTagDTO) {
 		const color = parseTagColor(payload.color);
-		const baseSlug = generateSlug(payload.name) || 'tag';
+		const customSlug = payload.slug?.trim();
+		const baseSlug = customSlug || generateSlug(payload.name) || 'tag';
 		let suffix = 1;
 
 		while (true) {
-			const slug = suffix === 1 ? baseSlug : `${baseSlug}-${suffix}`;
+			const slug = customSlug || (suffix === 1 ? baseSlug : `${baseSlug}-${suffix}`);
 			const id = TagIdentifier.generate();
 
 			try {
@@ -36,20 +40,25 @@ export class TagRepository {
 						color,
 					})
 					.execute();
-
-				return Tag.create({
-					id,
-					name: payload.name,
-					slug,
-					color,
-				});
 			} catch (error) {
 				if (!isTagSlugUniqueConstraintViolation(error)) {
 					throw error;
 				}
 
+				if (customSlug) {
+					throw new TagSlugAlreadyExistsError();
+				}
+
 				suffix += 1;
+				continue;
 			}
+
+			return Tag.create({
+				id,
+				name: payload.name,
+				slug,
+				color,
+			});
 		}
 	}
 

--- a/apps/romainlanz.com/inertia/components/admin/taxonomies/tag_table.vue
+++ b/apps/romainlanz.com/inertia/components/admin/taxonomies/tag_table.vue
@@ -1,0 +1,34 @@
+<script lang="ts" setup>
+	import Table from '@rlanz/design-system/table';
+	import Tag from '@rlanz/design-system/tag';
+	import type { TagColor } from '@rlanz/design-system/tag-color';
+
+	defineProps<{
+		items: Array<{ name: string; slug: string; color: TagColor }>;
+	}>();
+
+	const headers = [
+		{
+			label: 'Nom',
+			key: 'name',
+		},
+		{
+			label: 'Slug',
+			key: 'slug',
+		},
+		{
+			label: 'Couleur',
+			key: 'color',
+			cell: 'color',
+			width: '140px',
+		},
+	];
+</script>
+
+<template>
+	<Table :headers :items="items">
+		<template #color="{ item }">
+			<Tag :color="item.color">{{ item.color }}</Tag>
+		</template>
+	</Table>
+</template>

--- a/apps/romainlanz.com/inertia/pages/admin/taxonomies/list.vue
+++ b/apps/romainlanz.com/inertia/pages/admin/taxonomies/list.vue
@@ -1,6 +1,9 @@
 <script lang="ts" setup>
 	import { Data } from '@generated/data';
+	import Button from '@rlanz/design-system/button';
+	import { client } from '~/client';
 	import CategoryTable from '~/components/admin/taxonomies/category_table.vue';
+	import TagTable from '~/components/admin/taxonomies/tag_table.vue';
 	import { usePageTitle } from '~/composables/use_page_title';
 
 	const { vm } = defineProps<{
@@ -8,11 +11,29 @@
 	}>();
 
 	usePageTitle('Taxonomy');
+
+	const newCategoryUrl = client.urlFor('admin.taxonomies.categories.create');
+	const newTagUrl = client.urlFor('admin.taxonomies.tags.create');
 </script>
 
 <template>
-	<div class="flex flex-col gap-4">
-		<h2>Catégories</h2>
-		<CategoryTable :items="vm.categories" />
+	<div class="flex flex-col gap-8">
+		<section class="flex flex-col gap-4">
+			<div class="flex items-center justify-between gap-4">
+				<h2>Catégories</h2>
+				<Button color="violet" :href="newCategoryUrl">Créer</Button>
+			</div>
+
+			<CategoryTable :items="vm.categories" />
+		</section>
+
+		<section class="flex flex-col gap-4">
+			<div class="flex items-center justify-between gap-4">
+				<h2>Tags</h2>
+				<Button color="violet" :href="newTagUrl">Créer</Button>
+			</div>
+
+			<TagTable :items="vm.tags" />
+		</section>
 	</div>
 </template>

--- a/apps/romainlanz.com/inertia/pages/admin/taxonomies/tags/create.vue
+++ b/apps/romainlanz.com/inertia/pages/admin/taxonomies/tags/create.vue
@@ -1,0 +1,70 @@
+<script lang="ts" setup>
+	import { Form } from '@adonisjs/inertia/vue';
+	import Button from '@rlanz/design-system/button';
+	import Field from '@rlanz/design-system/field';
+	import FieldSelect from '@rlanz/design-system/field-select';
+	import Panel from '@rlanz/design-system/panel';
+	import { tagColors } from '@rlanz/design-system/tag-color';
+	import { ref, watch } from 'vue';
+	import { usePageTitle } from '~/composables/use_page_title';
+
+	usePageTitle('Créer un tag');
+
+	const name = ref('');
+	const slug = ref('');
+	const slugWasEdited = ref(false);
+	const color = ref<string[]>(['cyan']);
+	const colors = tagColors.map((tagColor) => ({
+		label: tagColor,
+		value: tagColor,
+	}));
+
+	watch(name, (value) => {
+		if (!slugWasEdited.value) {
+			slug.value = generateSlug(value);
+		}
+	});
+
+	function handleSlugInput(value: string) {
+		slugWasEdited.value = true;
+		slug.value = value;
+	}
+
+	function generateSlug(value: string) {
+		return value
+			.normalize('NFD')
+			.replace(/[\u0300-\u036f]/g, '')
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '-')
+			.replace(/^-|-$/g, '');
+	}
+</script>
+
+<template>
+	<Panel>
+		<Form v-slot="{ errors }" route="admin.taxonomies.tags.store" class="flex flex-col gap-3">
+			<Field v-model="name" name="name" label="Nom" type="text" :error-message="errors.name" />
+			<Field
+				:model-value="slug"
+				name="slug"
+				label="Slug"
+				type="text"
+				:error-message="errors.slug"
+				@update:model-value="handleSlugInput"
+			/>
+			<input type="hidden" name="color" :value="color[0] ?? ''" />
+			<FieldSelect
+				v-model="color"
+				label="Couleur"
+				placeholder="Choisir une couleur"
+				:items="colors"
+				:error-message="errors.color"
+			/>
+
+			<div>
+				<Button color="violet" type="submit">Créer</Button>
+			</div>
+		</Form>
+	</Panel>
+</template>

--- a/apps/romainlanz.com/start/routes/admin.ts
+++ b/apps/romainlanz.com/start/routes/admin.ts
@@ -16,7 +16,11 @@ const {
 			ListRedirects: ListRedirectsController,
 			StoreRedirect: StoreRedirectController,
 		},
-		taxonomies: { ListTaxonomies: ListTaxonomiesController, StoreCategory: StoreCategoryController },
+		taxonomies: {
+			ListTaxonomies: ListTaxonomiesController,
+			StoreCategory: StoreCategoryController,
+			StoreTag: StoreTagController,
+		},
 	},
 } = controllers;
 
@@ -38,6 +42,8 @@ router
 		router.get('taxonomies', [ListTaxonomiesController, 'render']).as('taxonomies.index');
 		router.get('taxonomies/categories/create', [StoreCategoryController, 'render']).as('taxonomies.categories.create');
 		router.post('taxonomies/categories', [StoreCategoryController, 'execute']).as('taxonomies.categories.store');
+		router.get('taxonomies/tags/create', [StoreTagController, 'render']).as('taxonomies.tags.create');
+		router.post('taxonomies/tags', [StoreTagController, 'execute']).as('taxonomies.tags.store');
 	})
 	.prefix('admin')
 	.as('admin')

--- a/apps/romainlanz.com/start/vine.ts
+++ b/apps/romainlanz.com/start/vine.ts
@@ -3,4 +3,5 @@ import vine, { SimpleMessagesProvider } from '@vinejs/vine';
 vine.messagesProvider = new SimpleMessagesProvider({
 	required: 'Le champ {{ field }} est obligatoire',
 	email: 'Le champ {{ field }} doit être une adresse email valide',
+	'color.in': 'Cette couleur n’est pas disponible.',
 });

--- a/apps/romainlanz.com/tests/bootstrap.ts
+++ b/apps/romainlanz.com/tests/bootstrap.ts
@@ -1,6 +1,9 @@
+import { authApiClient } from '@adonisjs/auth/plugins/api_client';
 import app from '@adonisjs/core/services/app';
 import testUtils from '@adonisjs/core/services/test_utils';
 import { inertiaApiClient } from '@adonisjs/inertia/plugins/api_client';
+import { sessionApiClient } from '@adonisjs/session/plugins/api_client';
+import { shieldApiClient } from '@adonisjs/shield/plugins/api_client';
 import { apiClient } from '@japa/api-client';
 import { assert } from '@japa/assert';
 import { pluginAdonisJS } from '@japa/plugin-adonisjs';
@@ -14,7 +17,15 @@ import type { Config } from '@japa/runner/types';
  * Configure Japa plugins in the plugins array.
  * Learn more - https://japa.dev/docs/runner-config#plugins-optional
  */
-export const plugins: Config['plugins'] = [assert(), pluginAdonisJS(app), apiClient(), inertiaApiClient(app)];
+export const plugins: Config['plugins'] = [
+	assert(),
+	pluginAdonisJS(app),
+	apiClient(),
+	sessionApiClient(app),
+	authApiClient(app),
+	shieldApiClient(),
+	inertiaApiClient(app),
+];
 
 /**
  * Configure lifecycle function to run before and after all the

--- a/apps/romainlanz.com/tests/fixtures/admin_tag_fixture.ts
+++ b/apps/romainlanz.com/tests/fixtures/admin_tag_fixture.ts
@@ -1,0 +1,77 @@
+import { UserRepository } from '#auth/repositories/user_repository';
+import { FindTagBySlugQuery } from '#taxonomies/queries/find_tag_by_slug_query';
+import { AdminFactory, TagFactory } from '#tests/factories/index';
+import { DatabaseFixture } from '#tests/fixtures/database_fixture';
+import type { FactoryInsert } from '#tests/factories/index';
+import type { ApiClient } from '@japa/api-client';
+
+type TagInput = {
+	name: string;
+	slug?: string;
+	color: string;
+};
+
+type TaxonomiesPageProps = {
+	vm: {
+		tags: Array<{ name: string; slug: string; color: string }>;
+	};
+};
+
+export class AdminTagFixture extends DatabaseFixture {
+	readonly #findTagBySlug = new FindTagBySlugQuery();
+	readonly #userRepository = new UserRepository();
+
+	givenTag(input: Partial<FactoryInsert<'tags'>> = {}) {
+		return TagFactory.create(input);
+	}
+
+	async visitTaxonomiesAsAdmin(client: ApiClient) {
+		const adminRecord = await AdminFactory.create();
+		const admin = await this.#userRepository.findUserByEmail(adminRecord.email);
+
+		if (!admin) {
+			throw new Error('Admin user was not created');
+		}
+
+		const response = await client.get('/admin/taxonomies').loginAs(admin).withInertia();
+
+		response.assertStatus(200);
+		response.assertInertiaComponent('admin/taxonomies/list');
+
+		return response.inertiaProps as TaxonomiesPageProps;
+	}
+
+	async createTagAsAdmin(client: ApiClient, input: TagInput, options: { followRedirects?: boolean } = {}) {
+		const adminRecord = await AdminFactory.create();
+		const admin = await this.#userRepository.findUserByEmail(adminRecord.email);
+
+		if (!admin) {
+			throw new Error('Admin user was not created');
+		}
+
+		const request = client
+			.post('/admin/taxonomies/tags')
+			.loginAs(admin)
+			.withCsrfToken()
+			.header('referer', '/admin/taxonomies/tags/create');
+
+		if (options.followRedirects === false) {
+			request.redirects(0);
+		}
+
+		return request.form(input);
+	}
+
+	async thenTagShouldExist(slug: string, expected: Required<TagInput>) {
+		const tag = await this.#findTagBySlug.execute(slug);
+
+		this.assert.deepEqual(
+			{
+				name: tag.props.name,
+				slug: tag.props.slug,
+				color: tag.props.color,
+			},
+			expected,
+		);
+	}
+}

--- a/apps/romainlanz.com/tests/functional/admin/taxonomies/list_taxonomies.spec.ts
+++ b/apps/romainlanz.com/tests/functional/admin/taxonomies/list_taxonomies.spec.ts
@@ -1,0 +1,26 @@
+import { test } from '@japa/runner';
+import { AdminTagFixture } from '#tests/fixtures/admin_tag_fixture';
+
+test.group('Admin taxonomy listing', (group) => {
+	let fixture: AdminTagFixture;
+
+	group.each.setup(async () => {
+		fixture = new AdminTagFixture();
+		await fixture.resetDatabase();
+	});
+
+	test('lists Tags with their admin fields', async ({ client, assert }) => {
+		await fixture.givenTag({ name: 'Adonis JS', slug: 'adonis', color: 'cyan' });
+		await fixture.givenTag({ name: 'Vue JS', slug: 'vue', color: 'lime' });
+
+		const props = await fixture.visitTaxonomiesAsAdmin(client);
+
+		assert.deepEqual(
+			props.vm.tags.map(({ name, slug, color }) => ({ name, slug, color })),
+			[
+				{ name: 'Adonis JS', slug: 'adonis', color: 'cyan' },
+				{ name: 'Vue JS', slug: 'vue', color: 'lime' },
+			],
+		);
+	});
+});

--- a/apps/romainlanz.com/tests/functional/admin/taxonomies/tags/create_tag.spec.ts
+++ b/apps/romainlanz.com/tests/functional/admin/taxonomies/tags/create_tag.spec.ts
@@ -1,0 +1,78 @@
+import { test } from '@japa/runner';
+import { AdminTagFixture } from '#tests/fixtures/admin_tag_fixture';
+
+test.group('Admin tag creation', (group) => {
+	let fixture: AdminTagFixture;
+
+	group.each.setup(async () => {
+		fixture = new AdminTagFixture();
+		await fixture.resetDatabase();
+	});
+
+	test('creates a Tag from the admin with a controlled color', async ({ client }) => {
+		const response = await fixture.createTagAsAdmin(client, {
+			name: 'Vue JS',
+			slug: 'vue',
+			color: 'cyan',
+		});
+
+		response.assertRedirectsTo('/admin/taxonomies');
+		await fixture.thenTagShouldExist('vue', {
+			name: 'Vue JS',
+			slug: 'vue',
+			color: 'cyan',
+		});
+	});
+
+	test('generates the Tag slug from the name when no slug is provided', async ({ client }) => {
+		const response = await fixture.createTagAsAdmin(client, {
+			name: 'Vue JS',
+			color: 'cyan',
+		});
+
+		response.assertRedirectsTo('/admin/taxonomies');
+		await fixture.thenTagShouldExist('vue-js', {
+			name: 'Vue JS',
+			slug: 'vue-js',
+			color: 'cyan',
+		});
+	});
+
+	test('rejects a Tag when the slug already exists', async ({ client }) => {
+		await fixture.givenTag({ name: 'Adonis JS', slug: 'adonis', color: 'cyan' });
+
+		const response = await fixture.createTagAsAdmin(
+			client,
+			{
+				name: 'Adonis Framework',
+				slug: 'adonis',
+				color: 'lime',
+			},
+			{ followRedirects: false },
+		);
+
+		response.assertStatus(302);
+		response.assertHeader('location', '/admin/taxonomies/tags/create');
+		response.assertFlashMessage('inputErrorsBag', {
+			slug: ['Ce slug est déjà utilisé.'],
+		});
+	});
+
+	test('rejects a Tag when the color is not controlled by the design system', async ({ client }) => {
+		const response = await fixture.createTagAsAdmin(
+			client,
+			{
+				name: 'TypeScript',
+				slug: 'typescript',
+				color: 'orange',
+			},
+			{ followRedirects: false },
+		);
+
+		response.assertStatus(302);
+		response.assertHeader('location', '/admin/taxonomies/tags/create');
+		response.assertFlashMessage('inputErrorsBag', {
+			color: ['Cette couleur n’est pas disponible.'],
+		});
+	});
+});


### PR DESCRIPTION
## Résumé

Closes #48

Cette PR ajoute la gestion des tags dans l’admin Taxonomies.

- Ajoute une section Tags dans la page Taxonomies avec consultation des tags existants.
- Ajoute la création d’un tag avec nom, slug ajustable et couleur contrôlée par le design system.
- Génère le slug depuis le nom quand l’admin ne le modifie pas.
- Affiche les erreurs de validation pertinentes pour le slug unique et la couleur.
- Ajoute les tests fonctionnels de listing et de création des tags admin.

## Validation

- `yarn workspace @rlanz/site test functional`
- `yarn format:check`
- `yarn lint`
- `yarn typecheck`