### PR TITLE
Fix execution of countPublishedArticles in list_articles_controller

### DIFF
--- a/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
+++ b/apps/romainlanz.com/app/articles/controllers/list_articles_controller.ts
@@ -33,7 +33,7 @@ export default class ListArticlesController {
 		const categoryListingAllArticlesCountPromise =
 			categorySlug === null && tagSlug === null
 				? paginationArticlesCountPromise
-				: this.countPublishedArticles.execute({ categorySlug: null, tagSlug: null });
+				: await this.countPublishedArticles.execute({ categorySlug: null, tagSlug: null });
 
 		const [articles, categories, categoryListingAllArticlesCount, paginationArticlesCount] = await Promise.all([
 			this.listPublishedArticles.execute({ page, perPage: 4, categorySlug, tagSlug }),


### PR DESCRIPTION
## Fix

Adds the missing `await` on the `countPublishedArticles.execute()` call in `ListArticlesController`.

### Problem

When `categorySlug` or `tagSlug` was non-null, `countPublishedArticles.execute()` was called without `await`. As a result, `categoryListingAllArticlesCountPromise` held an unresolved `Promise` instead of the expected value, causing incorrect behavior in the subsequent `Promise.all()`.

### Solution

Added `await` to ensure the value is properly resolved before being passed to `Promise.all()`.